### PR TITLE
docs: add project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # project1
+
+## 项目目的
+
+- 自动生成监管 XML 报表。
+
+## 前置条件
+
+- 已安装 Python 3.x。
+- 执行 `pip install -r requirements.txt` 安装依赖。
+- 配置数据库连接与输入数据源。
+
+## 使用示例
+
+1. 准备待处理的数据文件。
+2. 运行 `python main.py`。
+3. 在 `output/` 目录查看生成的 XML 报表。
+


### PR DESCRIPTION
## Summary
- document project purpose for generating regulatory XML reports
- outline prerequisites and basic usage example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef3ec5680832eacbc5c3226cac878