### PR TITLE
Add project tooling, CI, and contribution docs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Lint with flake8
+        run: flake8 .
+      - name: Check formatting with black
+        run: black --check .
+      - name: Run tests
+        run: pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Initial project structure and tooling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thank you for considering contributing to this project.
+
+## Development Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt -r requirements-dev.txt
+   ```
+2. Run linters:
+   ```bash
+   flake8 .
+   black --check .
+   ```
+3. Run tests:
+   ```bash
+   pytest
+   ```
+
+## Pull Request Process
+
+1. Fork the repository and create your branch from `main`.
+2. Ensure code passes linting and tests.
+3. Submit a pull request with a clear description of changes.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # project1
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing.
+
+Refer to [CHANGELOG.md](CHANGELOG.md) for project history and [docs/roadmap.md](docs/roadmap.md) for upcoming plans.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,12 @@
+# Roadmap
+
+This document outlines planned improvements and release milestones.
+
+## v0.1.0
+- Set up basic project scaffolding and tooling.
+
+## v0.2.0
+- Add core features.
+
+## v1.0.0
+- Stable release with complete documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+flake8
+black
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Runtime dependencies
+# (none currently)


### PR DESCRIPTION
## Summary
- add requirements files for runtime and dev dependencies
- configure flake8, black, and pytest
- add CI workflow for linting and tests
- document contributing guidelines, changelog, and roadmap
- link new docs from README

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement flake8: ProxyError)*
- `flake8 .` *(fails: command not found)*
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f15c74a4c832e8ee12691eacb8f05