### PR TITLE
Add Word template parsing and data autofill

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,22 @@
+from src.template_loader import parse_template
+from src.data_persistence import load_previous_data, autofill_fields
+from typing import List, Dict
+import json
+
+def generate_form(template_path: str, data_path: str) -> List[Dict[str, str]]:
+    fields = parse_template(template_path)
+    data = load_previous_data(data_path)
+    return autofill_fields(fields, data)
+
+
+def main(template_path: str, data_path: str) -> None:
+    filled = generate_form(template_path, data_path)
+    print(json.dumps(filled, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 3:
+        print("Usage: python main.py <template.docx> <data.json>")
+    else:
+        main(sys.argv[1], sys.argv[2])

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# package initialization

--- a/src/data_persistence.py
+++ b/src/data_persistence.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+def load_previous_data(path: str) -> Dict[str, str]:
+    """Load previous data from a JSON file."""
+    data_path = Path(path)
+    if not data_path.exists():
+        return {}
+    with data_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def autofill_fields(fields: List[Dict[str, str]], data: Dict[str, str]) -> List[Dict[str, str]]:
+    """Populate ``value`` for fields using the provided data."""
+    filled = []
+    for field in fields:
+        value = data.get(field["name"])
+        new_field = dict(field)
+        if value is not None:
+            new_field["value"] = value
+        filled.append(new_field)
+    return filled
+

--- a/src/template_loader.py
+++ b/src/template_loader.py
@@ -1,0 +1,44 @@
+import re
+import zipfile
+from xml.etree import ElementTree as ET
+from typing import List, Dict
+
+
+def parse_template(template_path: str) -> List[Dict[str, str]]:
+    """Parse a Word (.docx) template and extract form fields.
+
+    The function scans text nodes in the document for patterns like
+    ``Label: {{field_name}}`` and converts them into a structure suitable
+    for generating input forms.
+
+    Parameters
+    ----------
+    template_path: str
+        Path to the Word template file.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        A list of field definitions with keys ``label``, ``name`` and ``type``.
+    """
+    with zipfile.ZipFile(template_path) as zf:
+        xml_data = zf.read("word/document.xml")
+
+    root = ET.fromstring(xml_data)
+    ns = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+    fields: List[Dict[str, str]] = []
+    pattern = re.compile(r"(.+?)\{\{(\w+)\}\}")
+
+    for t in root.iter("{http://schemas.openxmlformats.org/wordprocessingml/2006/main}t"):
+        if not t.text:
+            continue
+        match = pattern.search(t.text)
+        if match:
+            label, name = match.groups()
+            fields.append({
+                "label": label.strip().rstrip(":："),
+                "name": name.strip(),
+                "type": "text",
+            })
+    return fields
+

--- a/tests/test_template_loader.py
+++ b/tests/test_template_loader.py
@@ -1,0 +1,68 @@
+import sys, os
+import json
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import zipfile
+from pathlib import Path
+
+from src.template_loader import parse_template
+from main import generate_form
+
+
+def create_docx(path: Path) -> None:
+    files = {
+        "[Content_Types].xml": (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
+            "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
+            "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
+            "<Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>"
+            "<Override PartName=\"/word/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml\"/>"
+            "</Types>"
+        ),
+        "_rels/.rels": (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+            "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"word/document.xml\"/>"
+            "</Relationships>"
+        ),
+        "word/_rels/document.xml.rels": (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"></Relationships>"
+        ),
+        "word/styles.xml": (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            "<w:styles xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"></w:styles>"
+        ),
+        "word/document.xml": (
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">"
+            "<w:body>"
+            "<w:p><w:r><w:t>Name: {{name}}</w:t></w:r></w:p>"
+            "<w:p><w:r><w:t>Age: {{age}}</w:t></w:r></w:p>"
+            "</w:body></w:document>"
+        ),
+    }
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+
+
+def test_parse_template(tmp_path: Path):
+    docx_path = tmp_path / "template.docx"
+    create_docx(docx_path)
+    fields = parse_template(str(docx_path))
+    assert fields == [
+        {"label": "Name", "name": "name", "type": "text"},
+        {"label": "Age", "name": "age", "type": "text"},
+    ]
+
+
+def test_generate_form_autofill(tmp_path: Path):
+    docx_path = tmp_path / "template.docx"
+    create_docx(docx_path)
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps({"name": "Alice", "age": "30"}), encoding="utf-8")
+    result = generate_form(str(docx_path), str(data_path))
+    assert any(f["name"] == "name" and f.get("value") == "Alice" for f in result)
+    assert any(f["name"] == "age" and f.get("value") == "30" for f in result)


### PR DESCRIPTION
## Summary
- parse Word `.docx` templates to form field definitions
- load previous JSON data and autofill field values
- expose form generation via `main.py`
- cover template parsing and autofill with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f15c7223c832eae17810e40ad51c8